### PR TITLE
Illustrating how to use calibrator for a complex mechanism

### DIFF
--- a/autodp/autodp_core.py
+++ b/autodp/autodp_core.py
@@ -249,6 +249,23 @@ class Mechanism():
         else:
             print(type_of_update, ' not recognized.')
 
+
+    def set_all_representation(self, mech):
+        """
+        Set all representations from a mechanism object. This is useful when constructing a
+        mechanism object using transformers then wanted to convert to a mechanism class definition.
+
+        :param mech:  Input mechanism object.
+        :return: None
+        """
+        # Need to make sure that the input is a mechanism object
+
+        self.approxDP = mech.approxDP
+        self.RenyiDP = mech.RenyiDP
+        self.fDP = mech.fDP
+        self.eps_pureDP = mech.eps_pureDP
+        self.delta0 = mech.delta0
+
     # Plotting functions: returns lines for people to plot outside
 
     # Plot FNR against FPR --- hypothesis testing interpretation of DP

--- a/example/example_calibrator.py
+++ b/example/example_calibrator.py
@@ -49,8 +49,6 @@ mech4 = general_calibrate(SubsampleGaussianMechanism, eps, delta, [0,1000],param
 print(mech4.name, mech4.params, mech4.get_approxDP(delta))
 
 
-
-
 """
 
 Cases 4: single parameter for Laplace mechanism, no subsample or composition
@@ -63,4 +61,85 @@ eps = 0.1
 delta = 1e-6
 mech = calibrate(LaplaceMechanism,eps,delta,[0,100],name='Laplace')
 print(mech.name, mech.params, mech.get_approxDP(delta))
+
+
+"""
+Case 5:  Calibration of complexed mechanism coming out of composition / sampling
+"""
+
+
+from autodp.mechanism_zoo import ExactGaussianMechanism, PureDP_Mechanism
+from autodp.transformer_zoo import Composition
+
+# We will consider the following complex mechanism fronm "example_composition.py"
+
+# run gm1 for 3 rounds
+# run gm2 for 5 times
+# run SVT for once
+# compose them with the transformation: compose.
+
+# What we will have to do is to define a new mechanism class based on the above object,
+# which involves two modular steps
+
+# The first step is to package this in a function where the input are the parameters,
+# and the output is the mechanism object
+
+def create_complex_mech(sigma1,sigma2,eps, coeffs):
+    gm1 = ExactGaussianMechanism(sigma1, name='GM1')
+    gm2 = ExactGaussianMechanism(sigma2, name='GM2')
+    SVT = PureDP_Mechanism(eps=eps, name='SVT')
+
+    # run gm1 for 3 rounds
+    # run gm2 for 5 times
+    # run SVT for once
+    # compose them with the transformation: compose.
+    compose = Composition()
+    composed_mech = compose([gm1, gm2, SVT], coeffs)
+    return composed_mech
+
+# next we can create it as a mechanism class, which requires us to inherit the base mechanism class,
+#  which we import now
+
+from autodp.autodp_core import Mechanism
+
+class Complex_Mechanism(Mechanism):
+    def __init__(self, params, name="A_Good_Name"):
+        self.name = name
+        self.params = params
+        mech = create_complex_mech(params['sigma1'], params['sigma2'], params['eps'], params['coeffs'])
+        # The following will set the function representation of the complex mechanism
+        # to be the same as that of the mech
+        self.set_all_representation(mech)
+
+
+# Now one can calibrate the mechanism to achieve a pre-defined privacy budget
+
+# Let's say we want to fix sigma1 and sigma2 while tuning the eps parameter from SVT
+
+sigma1 = 5.0
+sigma2 = 8.0
+
+coeffs = [3, 5, 1]
+
+# Let's say we are to calibrate the noise to the following privacy budget
+eps_budget = 2.5
+
+delta_budget= 1e-6
+
+# declare a general_calibrate "Calibrator"
+
+general_calibrate = generalized_eps_delta_calibrator()
+params = {}
+params['sigma1'] = sigma1
+params['sigma2'] = sigma2
+params['coeffs'] = coeffs
+params['eps'] = None
+
+
+mech_bob = general_calibrate(Complex_Mechanism, eps_budget, delta_budget, [0,50],params=params,
+                             para_name='eps',
+                             name='Complex_Mech_Bob')
+
+print(mech_bob.name, mech_bob.params, mech_bob.get_approxDP(delta))
+
 

--- a/tutorials/tutorial_calibrator.ipynb
+++ b/tutorials/tutorial_calibrator.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,8 +33,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GM {'sigma': 36.30468875627065} 0.10000000492560457\n",
-      "Ana_GM {'sigma': 36.304691899114694} 0.09999999565548193\n"
+      "GM {'sigma': 36.304688756269286} 0.10000000492560832\n",
+      "Ana_GM {'sigma': 36.304691899114694} 0.09999999565548537\n"
      ]
     }
    ],
@@ -55,12 +55,10 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Example 2: Calibration with Gaussian mechanism under composition"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -82,7 +80,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2522: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
       "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
      ]
     }
@@ -105,12 +103,10 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Example 3:  calibration with SubsampledGaussian mechanism"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
@@ -136,16 +132,14 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Example 4: Calibration with single parameter for Laplace mechanism"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -169,6 +163,127 @@
     "print(mech.name, mech.params, mech.get_approxDP(delta))\n",
     "#[0, 100] is the range of laplace parameter b.\n",
     "# to calibrate the noise for the composed Laplace mechanism, we can define a new composed Lapalce mechanism in mechanism.zoo (similar with Example 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 5: Calibration of a Complex Mechanism Created using AutoDP API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Remember Example 1 of the tutorial for the new API? This is when we compose Gaussian mechanism for 3 times,  another Gaussian mechanism for 5 times, then a Sparse Vector emchanism (as a pure-DP mechanism) for just once?\n",
+    "\n",
+    "The straightforward implementation is the following:\n",
+    "\n",
+    "\n",
+    "------------\n",
+    "```\n",
+    "from autodp.mechanism_zoo import ExactGaussianMechanism, PureDP_Mechanism\n",
+    "from autodp.transformer_zoo import Composition\n",
+    "\n",
+    "sigma1 = 5.0\n",
+    "sigma2 = 8.0\n",
+    "\n",
+    "gm1 = ExactGaussianMechanism(sigma1,name='GM1')\n",
+    "gm2 = ExactGaussianMechanism(sigma2,name='GM2')\n",
+    "SVT = PureDP_Mechanism(eps=0.1,name='SVT')\n",
+    "\n",
+    "composed_mech = compose([gm1, gm2, SVT], [3, 5, 1])\n",
+    "```\n",
+    "------------\n",
+    "\n",
+    "As we can see it was quite easy to create this mechanism object on-the-fly by the mechanism API. In particular, whenever transformers are used, then we can easily spin-up a *Mechanism object* in the runtime, but it doesn't give us a *Mechanissm class definition* that is needed to use our generic calibration tool.  This example illustrates how to convert this into a mechanism class and use our calibator.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Complex_Mech_Bob {'sigma1': 5.0, 'sigma2': 8.0, 'coeffs': [3, 5, 1], 'eps': 0.4168098107957052} 2.4999997197775063\n"
+     ]
+    }
+   ],
+   "source": [
+    "# The first step is to package this in a function where the input are the parameters,\n",
+    "# and the output is the mechanism object\n",
+    "\n",
+    "def create_complex_mech(sigma1,sigma2,eps, coeffs):\n",
+    "    gm1 = ExactGaussianMechanism(sigma1, name='GM1')\n",
+    "    gm2 = ExactGaussianMechanism(sigma2, name='GM2')\n",
+    "    SVT = PureDP_Mechanism(eps=eps, name='SVT')\n",
+    "\n",
+    "    # run gm1 for 3 rounds\n",
+    "    # run gm2 for 5 times\n",
+    "    # run SVT for once\n",
+    "    # compose them with the transformation: compose.\n",
+    "    compose = Composition()\n",
+    "    composed_mech = compose([gm1, gm2, SVT], coeffs)\n",
+    "    return composed_mech\n",
+    "\n",
+    "# next we can create it as a mechanism class, which requires us to inherit the base mechanism class,\n",
+    "#  which we import now\n",
+    "\n",
+    "from autodp.autodp_core import Mechanism\n",
+    "\n",
+    "class Complex_Mechanism(Mechanism):\n",
+    "    def __init__(self, params, name=\"A_Good_Name\"):\n",
+    "        self.name = name\n",
+    "        self.params = params\n",
+    "        mech = create_complex_mech(params['sigma1'], params['sigma2'], params['eps'], params['coeffs'])\n",
+    "        # The following will set the function representation of the complex mechanism\n",
+    "        # to be the same as that of the mech\n",
+    "        self.set_all_representation(mech)\n",
+    "\n",
+    "\n",
+    "# Now one can calibrate the mechanism to achieve a pre-defined privacy budget\n",
+    "\n",
+    "# Let's say we want to fix sigma1 and sigma2 while tuning the eps parameter from SVT\n",
+    "\n",
+    "sigma1 = 5.0\n",
+    "sigma2 = 8.0\n",
+    "\n",
+    "coeffs = [3, 5, 1]\n",
+    "\n",
+    "# Let's say we are to calibrate the noise to the following privacy budget\n",
+    "eps_budget = 2.5\n",
+    "\n",
+    "delta_budget= 1e-6\n",
+    "\n",
+    "# declare a general_calibrate \"Calibrator\"\n",
+    "\n",
+    "general_calibrate = generalized_eps_delta_calibrator()\n",
+    "\n",
+    "# Set those parameters that we want to fix and leave \n",
+    "params = {}\n",
+    "params['sigma1'] = sigma1\n",
+    "params['sigma2'] = sigma2\n",
+    "params['coeffs'] = coeffs\n",
+    "params['eps'] = None\n",
+    "\n",
+    "# Next, jussts call `general_calibrate` to find the right value of `eps` \n",
+    "# to give us the mechanism that achieves the required privacy-budget\n",
+    "mech_bob = general_calibrate(Complex_Mechanism, eps_budget, delta_budget, [0,50],params=params,\n",
+    "                             para_name='eps',\n",
+    "                             name='Complex_Mech_Bob')\n",
+    "\n",
+    "print(mech_bob.name, mech_bob.params, mech_bob.get_approxDP(delta))\n",
+    "\n",
+    "\n",
+    "# Notice that so far we support only calibration with one-dimensional parameter while keeping all other parameters fixed.\n",
+    "# Also the range [0,50] needs to be specified by the user so you many need to try a few times to get a feasible solution\n",
+    "\n",
+    "# The support for calibrating multiple parameters will be added later"
    ]
   }
  ],


### PR DESCRIPTION
created using Transformers and Mechanisms.

Main updates are: 

1. A ```set_all_representation``` function in the based ```autodp.Mechanism``` class.  This function takes a mechanism object and simply set all description of the current mechanism to be that of the input mechanism.  This is different from ```propogate_update``` because it does not try converting one representation to others, but simply take what is given. This is useful for declaring mechanism class using a mechanism object.

2. Adding Example 5 to ```tutorial_calibrator``` to illustrate how to do the above.