### PR TITLE
removing specified bounds for brents

### DIFF
--- a/autodp/converter.py
+++ b/autodp/converter.py
@@ -92,7 +92,7 @@ def rdp_to_delta(rdp):
                         result = utils.stable_logsumexp_two(term_1 - np.log(x)- np.log(delta),0)
                         return min(result*1.0/(x - 1), bbghs)
 
-                results = minimize_scalar(fun, method='Brent', bracket=(1, 2), bounds=[1, 100000])
+                results = minimize_scalar(fun, method='Brent', bracket=(1, 2))#, bounds=[1, 100000])
                 if results.success:
                    # print('delta', delta,'eps under rdp', results.fun)
                     return results.fun
@@ -146,7 +146,7 @@ def rdp_to_approxdp(rdp, alpha_max=np.inf, BBGHS_conversion=True):
                     else:
                         return np.log(1 / delta) / (x - 1) + rdp(x)
 
-            results = minimize_scalar(fun, method='Brent', bracket=(1,2), bounds=[1, alpha_max])
+            results = minimize_scalar(fun, method='Brent', bracket=(1,2))#, bounds=[1, alpha_max])
             if results.success:
                 return results.fun
             else:
@@ -250,7 +250,7 @@ def rdp_to_fdp(rdp, alpha_max=np.inf):
                 return -single_fdp(x)
 
         # This will use brent to start with 1,2.
-        results = minimize_scalar(fun, bracket=(0.5, 2), bounds=(0.5, alpha_max))
+        results = minimize_scalar(fun, bracket=(0.5, 2))#, bounds=(0.5, alpha_max))
         if results.success:
             return -results.fun
         else:
@@ -527,7 +527,7 @@ def rdp_to_fdp_and_fdp_grad_log(rdp, alpha_max=np.inf):
                 return log_one_minus_fdp_alpha(logx)
 
         # This will use brent to start with 1,2.
-        results = minimize_scalar(fun, bracket=(0.5, 2), bounds=(0.5, alpha_max))
+        results = minimize_scalar(fun, bracket=(0.5, 2))#, bounds=(0.5, alpha_max))
         if results.success:
             return [results.fun, results.x]
         else:
@@ -720,9 +720,9 @@ def fdp_fdp_grad_to_approxdp(fdp, fdp_grad, log_flag = False):
             bound1 = np.log(-tmp - tmp**2 / 2 - tmp**3 / 6)
         else:
             bound1 = np.log(1-np.exp(fun1(np.log(1-delta))))
-        #results = minimize_scalar(normal_equation, bounds=[-np.inf,0], bracket=[-1,-2])
-        results = minimize_scalar(normal_equation, method="Bounded", bounds=[bound1,0],
-                                  options={'xatol': 1e-10, 'maxiter': 500, 'disp': 0})
+        results = minimize_scalar(normal_equation, bracket=[-1,-2])
+        #results = minimize_scalar(normal_equation, method="Bounded", bounds=[bound1,0],
+        #                          options={'xatol': 1e-10, 'maxiter': 500, 'disp': 0})
         if results.success:
             if abs(results.fun) > 1e-4 and abs(results.x)>1e-10:
                 # This means that we hit xatol (x is close to 0, but

--- a/example/example_amplification_by_sampling.py
+++ b/example/example_amplification_by_sampling.py
@@ -38,9 +38,9 @@ composed_poissonsampled_mech1 = compose([poisson_sample(gm1,prob,improved_bound_
 
 
 # Now let's do subsampling. First we need to use replace-one version of the base mechanisms.
-gm1.replace_one = True
-gm2.replace_one = True
-SVT.replace_one = True
+gm1.neighboring = "replace_one"
+gm2.neighboring = "replace_one"
+SVT.neighboring = "replace_one"
 
 composed_subsampled_mech = compose([subsample(gm1,prob),
                                     subsample(gm2,prob),

--- a/tutorials/tutorial_PATE_with_autoDP.ipynb
+++ b/tutorials/tutorial_PATE_with_autoDP.ipynb
@@ -54,7 +54,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.2540846502197414 1e-06\n",
+      "2.2540846502197396 1e-06\n",
       "4.886554117462211 1e-06\n"
      ]
     },
@@ -62,7 +62,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2884: RuntimeWarning: invalid value encountered in scalar divide\n",
       "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
      ]
     }
@@ -111,8 +111,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PATE_eps=2 {'sigma': 22.30476293897311} 1.999999977711552\n",
-      "PATE_eps=0.5 {'sigma': 80.57618519751232} 0.49999999740790046\n"
+      "PATE_eps=2 {'sigma': 22.304762938973138} 1.9999999777115467\n",
+      "PATE_eps=0.5 {'sigma': 80.57618519751239} 0.49999999740789647\n"
      ]
     }
    ],
@@ -177,7 +177,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/tutorials/tutorial_calibrator.ipynb
+++ b/tutorials/tutorial_calibrator.ipynb
@@ -33,8 +33,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GM {'sigma': 36.304688756269286} 0.10000000492560832\n",
-      "Ana_GM {'sigma': 36.304691899114694} 0.09999999565548537\n"
+      "GM {'sigma': 36.30468875626822} 0.10000000492561108\n",
+      "Ana_GM {'sigma': 36.304691899114694} 0.09999999565548348\n"
      ]
     }
    ],
@@ -80,7 +80,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2884: RuntimeWarning: invalid value encountered in scalar divide\n",
       "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
      ]
     }
@@ -307,7 +307,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/tutorials/tutorial_fdp_of_basic_mechanisms.ipynb
+++ b/tutorials/tutorial_fdp_of_basic_mechanisms.ipynb
@@ -321,7 +321,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/tutorials/tutorial_new_api.ipynb
+++ b/tutorials/tutorial_new_api.ipynb
@@ -62,7 +62,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2884: RuntimeWarning: invalid value encountered in scalar divide\n",
       "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
      ]
     }
@@ -135,14 +135,14 @@
       "Generic composition: epsilon(delta) =  2.1309868424169824 , at delta =  1e-06\n",
       "Gaussian composition:  epsilon(delta) =  1.984273919801572 , at delta =  1e-06\n",
       "Generic composition: epsilon(delta) =  1.6484258167240666 , at delta =  0.0001\n",
-      "Gaussian composition:  epsilon(delta) =  1.4867384204500818 , at delta =  0.0001\n"
+      "Gaussian composition:  epsilon(delta) =  1.4867384204500813 , at delta =  0.0001\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2884: RuntimeWarning: invalid value encountered in scalar divide\n",
       "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
      ]
     }
@@ -265,11 +265,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2884: RuntimeWarning: invalid value encountered in scalar divide\n",
       "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n",
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2149: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2417: RuntimeWarning: invalid value encountered in scalar multiply\n",
       "  tmp2 = (x - v) * (fx - fw)\n",
-      "/Users/yuxiangw/Documents/bitbucket/autodp/autodp/autodp_core.py:233: RuntimeWarning: divide by zero encountered in log\n",
+      "/Users/yuxiangw/Documents/bitbucket/autodp/autodp/autodp_core.py:272: RuntimeWarning: divide by zero encountered in log\n",
       "  fdp = lambda x: 1 - np.exp(fun1(np.log(x)))\n"
      ]
     },
@@ -318,15 +318,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
-      "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2884: RuntimeWarning: invalid value encountered in scalar divide\n",
+      "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2417: RuntimeWarning: invalid value encountered in scalar multiply\n",
+      "  tmp2 = (x - v) * (fx - fw)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[5.298525912188081, 4.728386984943314, 4.7283856025045115, 4.377178095681224, 4.377178095627265, 1.4142111312027956]\n"
+      "[5.298525912188081, 4.728386984943314, 4.7283856417872805, 4.377178095681228, 4.377178095762625, 1.4142111312027956]\n"
      ]
     },
     {
@@ -406,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,9 +438,9 @@
     "\n",
     "\n",
     "# Now let's do subsampling. First we need to use replace-one version of the base mechanisms.\n",
-    "gm1.replace_one = True\n",
-    "gm2.replace_one = True\n",
-    "SVT.replace_one = True\n",
+    "gm1.neighboring = \"replace_one\"\n",
+    "gm2.neighboring = \"replace_one\"\n",
+    "SVT.neighboring = \"replace_one\"\n",
     "\n",
     "composed_subsampled_mech = compose([subsample(gm1,prob),\n",
     "                                    subsample(gm2,prob),\n",
@@ -453,17 +455,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
-      "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -482,7 +476,7 @@
       "epsilon(delta) =  0.48950668976148426 , at delta =  0.0001\n",
       "---------------------------------------------------\n",
       "Mechanism name is \" Compose:{Subsample:GM1: 30, Subsample:GM2: 50, Subsample:SVT: 10} \"\n",
-      "Parameters are:  {'Subsample:GM1:sigma': 5.0, 'Subsample:GM1:PoissonSample': 0.1, 'Subsample:GM1:Subsample': 0.1, 'Subsample:GM2:sigma': 8.0, 'Subsample:GM2:PoissonSample': 0.1, 'Subsample:GM2:Subsample': 0.1, 'Subsample:SVT:eps': 0.1, 'Subsample:SVT:PoissonSample': 0.1, 'Subsample:SVT:Subsample': 0.1}\n",
+      "Parameters are:  {'Subsample:GM1:sigma': 5.0, 'Subsample:GM1:Subsample': 0.1, 'Subsample:GM2:sigma': 8.0, 'Subsample:GM2:Subsample': 0.1, 'Subsample:SVT:eps': 0.1, 'Subsample:SVT:Subsample': 0.1}\n",
       "epsilon(delta) =  3.161674646617909 , at delta =  1e-06\n",
       "epsilon(delta) =  2.2643681643522973 , at delta =  0.0001\n",
       "------- If qualified for the improved bounds --------\n",
@@ -549,14 +543,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GM1 {'sigma': 2.904058395116701} 1.4999997486031456\n",
+      "GM1 {'sigma': 2.904058395116711} 1.4999997486031442\n",
       "Laplace {'eps': 1.500001569629506} 1.500001346499671\n"
      ]
     }
@@ -593,7 +587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -602,7 +596,7 @@
        "2.0677358464697515"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -624,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +644,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -748,7 +742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -775,6 +769,13 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -793,7 +794,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/tutorials/tutorial_online_query_release.ipynb
+++ b/tutorials/tutorial_online_query_release.ipynb
@@ -57,7 +57,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2884: RuntimeWarning: invalid value encountered in scalar divide\n",
       "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
      ]
     },
@@ -212,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/tutorials/tutorial_private_deep_learning.ipynb
+++ b/tutorials/tutorial_private_deep_learning.ipynb
@@ -42,7 +42,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/lib/python3.8/site-packages/scipy/optimize/optimize.py:2555: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "/usr/local/lib/python3.8/site-packages/scipy/optimize/_optimize.py:2884: RuntimeWarning: invalid value encountered in scalar divide\n",
       "  w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom\n"
      ]
     },
@@ -186,7 +186,7 @@
     {
      "data": {
       "text/plain": [
-       "10.997151214220652"
+       "10.99715121422065"
       ]
      },
      "execution_count": 3,
@@ -383,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
in "converter.py" it was reported that scipy no longer allows "minimize_scalar" to take "bounds" as an input when indicating that we wanted to use "brent" solver.  This is a temporary change to simply remove the "bounds".

TODOs:  reintroducing the bounds (known constraints for the solutions)  through the definition of the function to minimize itself. 